### PR TITLE
Java snippet generator

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -162,7 +162,7 @@ public class Runtime implements UnreportedStepExecutor {
     }
 
     public List<String> getSnippets() {
-        return undefinedStepsTracker.getSnippets(backends);
+        return undefinedStepsTracker.getSnippets(backends, runtimeOptions.getSnippetType());
     }
 
     public Glue getGlue() {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -37,6 +37,7 @@ public class RuntimeOptions {
     private boolean dryRun;
     private boolean strict = false;
     private boolean monochrome = false;
+    private SnippetType snippet = SnippetType.getDefault();
 
     public RuntimeOptions(Properties properties, String... argv) {
         /* IMPORTANT! Make sure USAGE.txt is always uptodate if this class changes */
@@ -97,6 +98,9 @@ public class RuntimeOptions {
                 strict = !arg.startsWith("--no-");
             } else if (arg.equals("--no-monochrome") || arg.equals("--monochrome") || arg.equals("-m")) {
                 monochrome = !arg.startsWith("--no-");
+            } else if (arg.equals("--snippets")) {
+                String nextArg = args.remove(0);
+                snippet = SnippetType.fromString(nextArg);
             } else if (arg.equals("--name") || arg.equals("-n")) {
                 String nextArg = args.remove(0);
                 Pattern patternFilter = Pattern.compile(nextArg);
@@ -201,5 +205,9 @@ public class RuntimeOptions {
 
     public boolean isMonochrome() {
         return monochrome;
+    }
+
+    public SnippetType getSnippetType() {
+        return snippet;
     }
 }

--- a/core/src/main/java/cucumber/runtime/SnippetType.java
+++ b/core/src/main/java/cucumber/runtime/SnippetType.java
@@ -1,0 +1,28 @@
+package cucumber.runtime;
+
+public enum SnippetType {
+    UNDERSCORE("underscore"),
+    CAMELCASE("camelcase");
+
+    private String type;
+
+    SnippetType(String type) {
+        this.type = type;
+    }
+
+    public static SnippetType fromString(String type) {
+        if (type == null) {
+            throw new IllegalArgumentException();
+        }
+        for (SnippetType snippetType : SnippetType.values()) {
+            if (type.equalsIgnoreCase(snippetType.type)) {
+                return snippetType;
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+
+    public static SnippetType getDefault() {
+        return UNDERSCORE;
+    }
+}

--- a/core/src/main/java/cucumber/runtime/SnippetTypeAwareBackend.java
+++ b/core/src/main/java/cucumber/runtime/SnippetTypeAwareBackend.java
@@ -1,0 +1,7 @@
+package cucumber.runtime;
+
+public interface SnippetTypeAwareBackend extends Backend {
+
+    public void setSnippetType(SnippetType type);
+
+}

--- a/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
@@ -22,11 +22,14 @@ public class UndefinedStepsTracker {
      * @return a list of code snippets that the developer can use to implement undefined steps.
      *         This should be displayed after a run.
      */
-    public List<String> getSnippets(Iterable<? extends Backend> backends) {
+    public List<String> getSnippets(Iterable<? extends Backend> backends, SnippetType type) {
         // TODO: Convert "And" and "But" to the Given/When/Then keyword above in the Gherkin source.
         List<String> snippets = new ArrayList<String>();
         for (Step step : undefinedSteps) {
             for (Backend backend : backends) {
+                if(backend instanceof SnippetTypeAwareBackend) {
+                    ((SnippetTypeAwareBackend) backend).setSnippetType(type);
+                }
                 String snippet = backend.getSnippet(step);
                 if (snippet == null) {
                     throw new NullPointerException("null snippet");
@@ -37,6 +40,15 @@ public class UndefinedStepsTracker {
             }
         }
         return snippets;
+    }
+
+    /**
+     * @param backends what backends we want snippets for
+     * @return a list of code snippets that the developer can use to implement undefined steps.
+     *         This should be displayed after a run.
+     */
+    public List<String> getSnippets(Iterable<? extends Backend> backends) {
+        return getSnippets(backends, SnippetType.getDefault());
     }
 
     public void storeStepKeyword(Step step, I18n i18n) {

--- a/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
+++ b/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.snippets;
 
 import cucumber.api.DataTable;
+import cucumber.runtime.SnippetType;
 import gherkin.I18n;
 import gherkin.formatter.model.Step;
 
@@ -10,7 +11,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public final class SnippetGenerator {
+public class SnippetGenerator {
     private static final ArgumentPattern[] DEFAULT_ARGUMENT_PATTERNS = new ArgumentPattern[]{
             new ArgumentPattern(Pattern.compile("\"([^\"]*)\""), String.class),
             new ArgumentPattern(Pattern.compile("(\\d+)"), Integer.TYPE)
@@ -73,7 +74,7 @@ public final class SnippetGenerator {
         return functionName;
     }
 
-    String sanitizeFunctionName(String functionName) {
+    protected String sanitizeFunctionName(String functionName) {
         StringBuilder sanitized = new StringBuilder();
 
         String trimmedFunctionName = functionName.trim();

--- a/core/src/main/resources/cucumber/runtime/USAGE.txt
+++ b/core/src/main/resources/cucumber/runtime/USAGE.txt
@@ -11,6 +11,7 @@ Options:
     -d, --[no-]-dry-run                Skip execution of glue code.
     -m, --[no-]-monochrome             Don't colour terminal output.
     -s, --[no-]-strict                 Treat undefined and pending steps as errors.
+        --snippets                     Snippet type: underscore, camelcase
         --dotcucumber PATH_OR_URL      Where to write out runtime information. PATH_OR_URL can be a file system
                                        path or a URL.
     -v, --version                      Print version.

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -196,4 +196,20 @@ public class RuntimeOptionsTest {
 
         verify((StrictAware)strictAwareFormatter).setStrict(true);
     }
+
+    @Test
+    public void default_snippet_type() {
+        Properties properties = new Properties();
+        RuntimeOptions runtimeOptions = new RuntimeOptions(properties);
+        assertEquals(SnippetType.UNDERSCORE, runtimeOptions.getSnippetType());
+    }
+
+    @Test
+    public void set_snippet_type() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--snippets camelcase");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(properties);
+        assertEquals(SnippetType.CAMELCASE, runtimeOptions.getSnippetType());
+    }
+
 }

--- a/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
+++ b/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
@@ -5,13 +5,12 @@ import cucumber.runtime.snippets.SnippetGenerator;
 import gherkin.I18n;
 import gherkin.formatter.model.Step;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class UndefinedStepsTrackerTest {
 
@@ -75,6 +74,19 @@ public class UndefinedStepsTrackerTest {
         tracker.addUndefinedStep(new Step(null, "Если ", "Б", 1, null, null), new I18n("ru"));
         assertEquals("[Если ^Б$]", tracker.getSnippets(asList(backend)).toString());
     }
+
+    @Test
+    public void set_snippet_type_on_capable_backends() {
+        Backend backend = Mockito.mock(SnippetTypeAwareBackend.class);
+        Mockito.when(backend.getSnippet(Mockito.any(Step.class))).thenReturn("");
+
+        UndefinedStepsTracker undefinedStepsTracker = new UndefinedStepsTracker();
+        undefinedStepsTracker.addUndefinedStep(new Step(null, "Given ", "A", 1, null, null), ENGLISH);
+        undefinedStepsTracker.getSnippets(asList(backend));
+        Mockito.verify((SnippetTypeAwareBackend) backend, Mockito.atLeastOnce()).setSnippetType(SnippetType.getDefault());
+
+    }
+
 
     private class TestBackend implements Backend {
         @Override

--- a/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
+++ b/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
@@ -10,7 +10,9 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class UndefinedStepsTrackerTest {
 

--- a/java/src/main/java/cucumber/runtime/java/CamelCaseSnippetGenerator.java
+++ b/java/src/main/java/cucumber/runtime/java/CamelCaseSnippetGenerator.java
@@ -1,0 +1,48 @@
+package cucumber.runtime.java;
+
+import cucumber.api.DataTable;
+import cucumber.runtime.snippets.ArgumentPattern;
+import cucumber.runtime.snippets.Snippet;
+import cucumber.runtime.snippets.SnippetGenerator;
+import gherkin.I18n;
+import gherkin.formatter.model.Step;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CamelCaseSnippetGenerator extends SnippetGenerator {
+
+    public CamelCaseSnippetGenerator(Snippet snippet) {
+        super(snippet);
+    }
+
+    @Override
+    protected String sanitizeFunctionName(String functionName) {
+
+        StringBuilder sanitized = new StringBuilder();
+
+        String trimmedFunctionName = functionName.trim();
+
+        if(!Character.isJavaIdentifierStart(trimmedFunctionName.charAt(0))) {
+            sanitized.append("_");
+        }
+
+        String[] words = trimmedFunctionName.split(" ");
+
+        sanitized.append(words[0].toLowerCase());
+
+        for(int i=1; i<words.length; i++) {
+            sanitized.append(capitalize(words[i].toLowerCase()));
+        }
+
+        return sanitized.toString();
+    }
+
+    private String capitalize(String line)
+    {
+        return Character.toUpperCase(line.charAt(0)) + line.substring(1);
+    }
+}

--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -12,13 +12,14 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class JavaBackend implements Backend {
-    private final SnippetGenerator snippetGenerator = new SnippetGenerator(new JavaSnippet());
+public class JavaBackend implements SnippetTypeAwareBackend {
+    private SnippetGenerator snippetGenerator = new SnippetGenerator(new JavaSnippet());
     private final ObjectFactory objectFactory;
     private final Reflections reflections;
 
     private final MethodScanner methodScanner;
     private Glue glue;
+    private SnippetType snippetType = SnippetType.getDefault();
 
     /**
      * The constructor called by reflection by default.
@@ -128,5 +129,19 @@ public class JavaBackend implements Backend {
             int timeout = ((After) annotation).timeout();
             glue.addAfterHook(new JavaHookDefinition(method, tagExpressions, ((After) annotation).order(), timeout, objectFactory));
         }
+    }
+
+    @Override
+    public void setSnippetType(SnippetType type) {
+        switch (type) {
+            case CAMELCASE:
+                snippetGenerator = new CamelCaseSnippetGenerator(new JavaSnippet());
+                break;
+            default:
+                snippetGenerator = new SnippetGenerator(new JavaSnippet());
+                break;
+
+        }
+        this.snippetType = type;
     }
 }

--- a/java/src/test/java/cucumber/runtime/java/CamelCaseSnippetGeneratorTest.java
+++ b/java/src/test/java/cucumber/runtime/java/CamelCaseSnippetGeneratorTest.java
@@ -1,0 +1,20 @@
+package cucumber.runtime.java;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CamelCaseSnippetGeneratorTest {
+
+    @Test
+    public void testSanitizeFunctionName() {
+
+        CamelCaseSnippetGenerator generator = new CamelCaseSnippetGenerator(new JavaSnippet());
+
+        String functionName = "I am a function name";
+        String expected = "iAmAFunctionName";
+        String actual = generator.sanitizeFunctionName(functionName);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -2,6 +2,7 @@ package cucumber.api.junit;
 
 import cucumber.runtime.Runtime;
 import cucumber.runtime.RuntimeOptions;
+import cucumber.runtime.SnippetType;
 import cucumber.runtime.io.MultiLoader;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.junit.Assertions;
@@ -141,5 +142,10 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         String[] name() default {};
 
         String dotcucumber() default "";
+
+        /**
+         * @return what format should the snippets use. underscore, camelcase
+         */
+        String snippets() default "underscore";
     }
 }

--- a/junit/src/main/java/cucumber/runtime/junit/RuntimeOptionsFactory.java
+++ b/junit/src/main/java/cucumber/runtime/junit/RuntimeOptionsFactory.java
@@ -28,6 +28,7 @@ public class RuntimeOptionsFactory {
         addStrict(options, args);
         addName(options, args);
         addDotCucumber(options, args);
+        addSnippets(options, args);
 
         RuntimeOptions runtimeOptions = new RuntimeOptions(System.getProperties(), args.toArray(new String[args.size()]));
 
@@ -50,6 +51,15 @@ public class RuntimeOptionsFactory {
                     args.add("--name");
                     args.add(name);
                 }
+            }
+        }
+    }
+
+    private void addSnippets(Cucumber.Options options, List<String> args) {
+        if (options != null) {
+            if (!options.snippets().isEmpty()) {
+                    args.add("--snippets");
+                    args.add(options.snippets());
             }
         }
     }

--- a/junit/src/test/java/cucumber/runtime/junit/RuntimeOptionsFactoryTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/RuntimeOptionsFactoryTest.java
@@ -2,6 +2,7 @@ package cucumber.runtime.junit;
 
 import cucumber.api.junit.Cucumber;
 import cucumber.runtime.RuntimeOptions;
+import cucumber.runtime.SnippetType;
 import org.junit.Test;
 
 import java.net.MalformedURLException;
@@ -72,6 +73,13 @@ public class RuntimeOptionsFactoryTest {
         assertEquals(new URL("https://some.where/.cucumber/"), runtimeOptions.getDotCucumber());
     }
 
+    @Test
+    public void create_with_snippets() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(Snippets.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertEquals(SnippetType.CAMELCASE, runtimeOptions.getSnippetType());
+    }
+
     private String getRegexpPattern(Object pattern) {
         return ((Pattern) pattern).pattern();
     }
@@ -84,6 +92,11 @@ public class RuntimeOptionsFactoryTest {
     @Test
     public void finds_path_for_class_in_toplevel_package() {
         assertEquals("", packageName("TopLevelClass"));
+    }
+
+    @Cucumber.Options(snippets = "camelcase")
+    static class Snippets {
+        // empty
     }
 
     @Cucumber.Options(strict = true)


### PR DESCRIPTION
Support for java style function names in snippets.

Configurable with --snippets in the cucumber.options. (junit and command line)
Values: underscore, camelcase
Default: underscore
